### PR TITLE
Correct typo #91

### DIFF
--- a/crib-cheat_markdown.md
+++ b/crib-cheat_markdown.md
@@ -156,13 +156,13 @@ I'm not but `I am!`
 
 # Horizontale Linien
 
-	Sowhol
+	Sowohl
 	***
 	funktioniert. Als auch
 	___
 	Unterstriche.
 
-Sowhol Sterne
+Sowohl Sterne
 ***
 funktionieren, als auch
 ___


### PR DESCRIPTION
In crib-cheat-markdown wurde "Sowhol" durch "Sowohl" ersetzt :)