### PR TITLE
add cloneguide #138

### DIFF
--- a/crib-cheat_git.md
+++ b/crib-cheat_git.md
@@ -33,6 +33,12 @@ cd C:/git/github/htw-pv3
 ## Cloning the Repository literature in htw-pv3/literature:
 git clone https://github.com/htw-pv3/literature.git
 
+		Guide: how to clone
+		1. Create the desired folder structure on your computer with the directory you want to clone into
+		2. Start git-bash and navigate with the "cd" command" into the created directory
+		3. Go to github.com to the appropriate repository (in this case https://github.com/htw-pv3/literature) and click on the green drop down button called "code" in the top left corner and copy the https
+		4. enter the command "git clone" in git-bash with the link (git clone https://github.com/htw-pv3/literature.git)
+		
 ## Cloning the Repository wheather-data in htw-pv3/weather-data:
  git clone https://github.com/htw-pv3/weather-data.git
 


### PR DESCRIPTION
adding guide how to clone in crib-cheat_git.md at line 3

[crib-cheat_git.md](https://github.com/htw-pv3/literature/files/8499819/crib-cheat_git.md)
3