### PR TITLE
Update Meld-Version auf 3.22.2 #250

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -229,10 +229,10 @@
   owner           = {Johannes},
   platform        = {independent},
   tag             = {{software;}},
-  timestamp       = {2020-04-27},
+  timestamp       = {2025-04-15},  
   url             = {https://meldmerge.org/},
-  urldate         = {2023-04-13},
-  version         = {3.22.0},
+  urldate         = {2025-04-15},
+  version         = {3.22.2},
   groups          = {Software},
 }
 


### PR DESCRIPTION
Ich habe den BibTeX-Eintrag zu Meld auf die aktuelle stabile Version 3.22.2 (vom 24. März 2024) aktualisiert.  
Zudem wurden `timestamp` und `urldate` auf den 15.04.2025 angepasst.

🔗 Quelle: https://meldmerge.org/  
🧾 Issue: #250
