### PR TITLE
Meld-Version aktualisiert auf 3.22.2 #255

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -241,9 +241,9 @@
   owner           = {Johannes},
   platform        = {independent},
   tag             = {{software;}},
-  timestamp       = {2020-04-27},
+  timestamp       = {2025-04-15},  
   url             = {https://meldmerge.org/},
-  urldate         = {2023-04-13},
+  urldate         = {2025-04-15},
   version         = {3.22.2},
   groups          = {Software},
 }


### PR DESCRIPTION
Zweiter Versuch, jetzt auf Basis von dev.
Die Version war in dev/references.bib  bereits aktuell (3.22.2), daher habe ichnur noch timestamp und urldate auf den aktuellen Stand gebracht.
Änderungen basieren auf PR #252. Siehe dazu auch Issue #255.