### PR TITLE
Revert "Update Notepad++ Version #297"

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -106,10 +106,10 @@
   owner           = {Kilian},
   platform        = {Windows},
   tag             = {{software;}{editor;}},
-  timestamp       = {2026-04-21},
+  timestamp       = {2025-04-29},
   url             = {https://notepad-plus-plus.org/},
-  urldate         = {2026-04-21},
-  version         = {8.9.3},
+  urldate         = {2020-04-26},
+  version         = {8.8},
   groups          = {Software},
 }
 


### PR DESCRIPTION
Der Merge in den production-Branch war ein Fehler. Ich mache das hiermit rückgängig, da die Änderungen in den develop-Branch gehören.